### PR TITLE
Allow markers to damage marked players

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Besides the normal role convars found in ULX, there are these special convars:
 # sets if the marker should be able to deal any damage
   ttt_mark_deal_no_damage [0/1] (def: 1)
 # sets if marked players should be able to deal any damage to the marker
+  ttt_mark_hurt_marked_factor [0.0..1.0] (def: 0)
+# for values > 0, the marker will be able to damaged marked players. The damage is scaled by this factor
   ttt_mark_take_no_damage [0/1] (def: 1)
 # defines the factor to calculate the amount of defis; set to 0 to disable
   ttt_mark_defi_factor [0.0..1.0] (def: 0.34)

--- a/lua/terrortown/autorun/client/cl_maker_targetid.lua
+++ b/lua/terrortown/autorun/client/cl_maker_targetid.lua
@@ -40,7 +40,7 @@ hook.Add("TTTRenderEntityInfo", "ttt2_marker_highlight_focused_players", functio
 		end
 	end
 
-	if GetGlobalBool("ttt_mark_deal_no_damage", false) then
+	if GetGlobalBool("ttt_mark_deal_no_damage", false) and not (MARKER_DATA:IsMarked(ent) and GetGlobalBool("ttt_mark_hurt_marked", false))  then
 		tData:AddDescriptionLine(
 			LANG.GetTranslation("ttt_marker_player_deal_no_damage"),
 			COLOR_ORANGE,

--- a/lua/terrortown/autorun/shared/sh_marker_convars.lua
+++ b/lua/terrortown/autorun/shared/sh_marker_convars.lua
@@ -9,6 +9,7 @@ CreateConVar("ttt_mark_take_no_damage", 1, {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 CreateConVar("ttt_mark_defi_factor", 0.34, {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 CreateConVar("ttt_mark_defi_revive_time", 2.0, {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 CreateConVar("ttt_mark_defi_error_time", 1.0, {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+CreateConVar("ttt_mark_hurt_marked_factor", 0, {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 
 if SERVER then
 	-- ConVar replication is broken in GMod, so we do this, at least Alf added a hook!
@@ -16,6 +17,7 @@ if SERVER then
 	hook.Add("TTT2SyncGlobals", "ttt2_marker_sync_convars", function()
 		SetGlobalBool("ttt_mark_deal_no_damage", GetConVar("ttt_mark_deal_no_damage"):GetBool())
 		SetGlobalBool("ttt_mark_take_no_damage", GetConVar("ttt_mark_take_no_damage"):GetBool())
+		SetGlobalBool("ttt_mark_hurt_marked", GetConVar("ttt_mark_hurt_marked_factor"):GetFloat() > 0)
 	end)
 
 	-- sync convars on change
@@ -25,6 +27,10 @@ if SERVER then
 
 	cvars.AddChangeCallback("ttt_mark_take_no_damage", function(cv, old, new)
 		SetGlobalBool("ttt_mark_take_no_damage", tobool(tonumber(new)))
+	end)
+
+	cvars.AddChangeCallback("ttt_mark_hurt_marked_factor", function(cv, old, new)
+		SetGlobalBool("ttt_mark_hurt_marked", tonumber(new) > 0)
 	end)
 end
 
@@ -42,4 +48,5 @@ hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_marker_convars", function(tbl)
 	table.insert(tbl[ROLE_MARKER], {cvar = "ttt_mark_defi_factor", slider = true, min = 0, max = 1, decimal = 2, desc = "ttt_mark_defi_factor (def. 0.34)"})
 	table.insert(tbl[ROLE_MARKER], {cvar = "ttt_mark_defi_revive_time", slider = true, min = 0, max = 30, decimal = 1, desc = "ttt_mark_defi_revive_time (def. 1.0)"})
 	table.insert(tbl[ROLE_MARKER], {cvar = "ttt_mark_defi_error_time", slider = true, min = 0, max = 30, decimal = 1, desc = "ttt_mark_defi_error_time (def. 1.0)"})
+	table.insert(tbl[ROLE_MARKER], {cvar = "ttt_mark_hurt_marked_factor", slider = true, min = 0, max = 1, decimal = 2, desc = "ttt_mark_hurt_marked_factor (def. 0.0)"})
 end)

--- a/lua/terrortown/entities/roles/marker/shared.lua
+++ b/lua/terrortown/entities/roles/marker/shared.lua
@@ -175,7 +175,13 @@ if SERVER then
 
 		if not attacker or not IsValid(attacker) or not attacker:IsPlayer() then return end
 
-		if attacker:GetTeam() == TEAM_MARKER and attacker ~= ply then
+		if attacker:GetTeam() ~= TEAM_MARKER or attacker == ply then return end
+
+		local dmg_scale = GetConVar("ttt_mark_hurt_marked_factor"):GetFloat()
+
+		if dmg_scale > 0 then
+			dmginfo:ScaleDamage(dmg_scale)
+		else
 			dmginfo:ScaleDamage(0)
 			dmginfo:SetDamage(0)
 		end


### PR DESCRIPTION
This pull request adds a convar, ttt_mark_hurt_marked_factor, to the marker role that allows the marker to damage marked players for values greater than 0. The total damage dealt by the marker to the marked player is scaled by this factor. This is to serve as a mitigation for marked players being able to handicap the marker by body blocking them in a room or something of that sort. The default value of the convar is 0, so the old behavior is still the default.