### PR TITLE
fix for specdm to allow damage from marker

### DIFF
--- a/lua/terrortown/entities/roles/marker/shared.lua
+++ b/lua/terrortown/entities/roles/marker/shared.lua
@@ -165,6 +165,8 @@ if SERVER then
 	end)
 
 	hook.Add("EntityTakeDamage", "TTT2MarkerDealNoDamage", function(ply, dmginfo)
+		if SpecDM and (ply.IsGhost and ply:IsGhost()) then return end
+
 		if not ply:IsPlayer() then return end
 
 		if not GetConVar("ttt_mark_deal_no_damage"):GetBool() then return end

--- a/lua/terrortown/lang/deutsch/marker.lua
+++ b/lua/terrortown/lang/deutsch/marker.lua
@@ -1,4 +1,4 @@
-local L = LANG.GetLanguageTableReference("deutsch")
+local L = LANG.GetLanguageTableReference("english")
 
 -- GENERAL ROLE LANGUAGE STRINGS
 L[MARKER.name] = "Markierer"

--- a/lua/terrortown/lang/deutsch/marker.lua
+++ b/lua/terrortown/lang/deutsch/marker.lua
@@ -1,4 +1,4 @@
-local L = LANG.GetLanguageTableReference("english")
+local L = LANG.GetLanguageTableReference("deutsch")
 
 -- GENERAL ROLE LANGUAGE STRINGS
 L[MARKER.name] = "Markierer"


### PR DESCRIPTION
Tested with and without specdm installed on the newest ttt2 version.
This fixes the problem where the marker can't do damage in specdm and also fixes the typo in the german lang file.