### PR TITLE
Added hook to prevent dmg to Pharaoh's ankh if Marker deals no dmg

### DIFF
--- a/lua/terrortown/entities/roles/marker/shared.lua
+++ b/lua/terrortown/entities/roles/marker/shared.lua
@@ -208,4 +208,10 @@ if SERVER then
 			dmginfo:SetDamage(0)
 		end
 	end)
+
+	hook.Add("TTT2PharaohPreventDamageToAnkh", "TTT2PharaohPreventDamageToAnkhMarker", function(attacker)
+		if attacker:GetTeam() == TEAM_MARKER and GetConVar("ttt_mark_deal_no_damage"):GetBool() then
+			return true
+		end
+	end)
 end


### PR DESCRIPTION
With this patch, if a Marker cannot deal damage to players, they cannot deal damage to ankhs. Reasoning for adding this is to prevent griefing (see: https://github.com/TTT-2/ttt2-role_pha/issues/7).